### PR TITLE
Switched to C++20 standard in CMakeLists.txt

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -54,7 +54,7 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
         -DBOOST_ALL_NO_LIB)
 else()
 # Replease c++11 with c++17 below in case C++ 17 should be used
-    add_definitions(-std=c++11 -fPIC)
+    add_definitions(-std=c++20 -fPIC)
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX)


### PR DESCRIPTION
We need the Avro C++ lib to use C++20 during compilation to be compatible
with other Scylla modules and submodules
